### PR TITLE
feat: filter images results to launch year

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,4 +1,13 @@
 {
     "configurations": [
+        {
+            "name": "Attach",
+            "port": 9229,
+            "request": "attach",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "pwa-node"
+        }
            ]
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nasa-media-gql",
+  "name": "spaceapi-media-graphql",
   "version": "1.0.0",
   "author": "Scott Jungling <scott.jungling@gmail.com>",
   "license": "MIT",
@@ -7,7 +7,7 @@
     "prebuild": "yarn generate",
     "prestart": "yarn generate",
     "build": "netlify-lambda build src/graphql --config ./webpack.config.js",
-    "start": "npx --node-arg=--inspect netlify-lambda serve src/graphql --config ./webpack.config.js",
+    "start": "npx --node-arg=--inspect netlify-lambda -p 8888 serve src/graphql --config ./webpack.config.js",
     "dev": "npx --node-arg=--inspect netlify dev",
     "generate": "graphql-codegen --config codegen.yml"
   },

--- a/src/graphql/nasa-media-data.ts
+++ b/src/graphql/nasa-media-data.ts
@@ -34,11 +34,22 @@ export default class NasaMediaAPI extends RESTDataSource {
     });
     return data;
   }
-  async searchMedia(query: string, media_type: Media_Type_Enum) {
-    const data = await this.get(`search`, {
+  async searchMedia(
+    query: string,
+    media_type: Media_Type_Enum,
+    date_range?: { start: string; end: string }
+  ) {
+    let queryParameters = {
       q: query,
       media_type: media_type.toLowerCase(),
-    });
+    };
+    if (date_range) {
+      queryParameters = Object.assign(queryParameters, {
+        year_start: new Date(date_range.start).getFullYear(),
+        year_end: new Date(date_range.end).getFullYear(),
+      });
+    }
+    const data = await this.get(`search`, queryParameters);
     return data;
   }
   async getAssetByNasaId(nasa_id: String) {

--- a/src/graphql/nasa-media-resolver.ts
+++ b/src/graphql/nasa-media-resolver.ts
@@ -58,10 +58,18 @@ export const NasaMediaResolvers: Resolvers = {
     },
   },
   Mission: {
-    images: async ({ mission }, { type, limit }, { dataSources }) => {
+    images: async (
+      { mission, launchDate },
+      { type, limit },
+      { dataSources }
+    ) => {
       if (type === "AUDIO")
         throw new Error("Audio results are not yet supported");
-      const response = await dataSources.nasa.searchMedia(mission, type);
+
+      const response = await dataSources.nasa.searchMedia(mission, type, {
+        start: launchDate,
+        end: launchDate,
+      });
       const results = response.collection.items
         .slice(0, limit ?? -1)
         .map((image) => formatImage(image))

--- a/src/graphql/nasa-media-schema.graphql
+++ b/src/graphql/nasa-media-schema.graphql
@@ -73,6 +73,14 @@ enum MEDIA_TYPE_ENUM {
 }
 
 extend type Mission @key(fields: "mission") {
+  # Required field - `@external`  as it is provided by `Mission` service and the primary key
   mission: String! @external
+  # Required field - `@external`  as it is provided by `Mission` service and used for additional search parameters
+  launchDate: DateTime! @external
+  """
+  Images from NASA Image Archives
+  @requires `launchDate` from `Mission` in order to filter results to year of launch
+  """
   images(type: MEDIA_TYPE_ENUM = IMAGE, limit: Int = 10): [Image!]!
+    @requires(fields: "launchDate")
 }


### PR DESCRIPTION
Requires `launchDate` from `Mission` in order to provide a start / end year query parameter for
underlying API

fix #4